### PR TITLE
remove panics from screw.go and return err

### DIFF
--- a/examples/bolt_container/main.go
+++ b/examples/bolt_container/main.go
@@ -8,7 +8,11 @@ Nuts and Bolts
 
 package main
 
-import . "github.com/deadsy/sdfx/sdf"
+import (
+	"log"
+
+	. "github.com/deadsy/sdfx/sdf"
+)
 
 //-----------------------------------------------------------------------------
 
@@ -23,7 +27,7 @@ var base_thickness = 4.0
 
 //-----------------------------------------------------------------------------
 
-func bolt_container() SDF3 {
+func bolt_container() (SDF3, error) {
 
 	// build hex head
 	hex := HexHead3D(hex_radius, hex_height, "tb")
@@ -31,7 +35,11 @@ func bolt_container() SDF3 {
 	// build the screw portion
 	r := screw_radius - tolerance
 	l := screw_length
-	screw := Screw3D(ISOThread(r, thread_pitch, "external"), l, thread_pitch, 1)
+	isoThread, err := ISOThread(r, thread_pitch, "external")
+	if err != nil {
+		return nil, err
+	}
+	screw := Screw3D(isoThread, l, thread_pitch, 1)
 	// chamfer the thread
 	screw = ChamferedCylinder(screw, 0, 0.25)
 	screw = Transform3D(screw, Translate3d(V3{0, 0, l / 2}))
@@ -44,7 +52,7 @@ func bolt_container() SDF3 {
 	cavity := Cylinder3D(l, r, round)
 	cavity = Transform3D(cavity, Translate3d(V3{0, 0, ofs}))
 
-	return Difference3D(Union3D(hex, screw), cavity)
+	return Difference3D(Union3D(hex, screw), cavity), nil
 }
 
 //-----------------------------------------------------------------------------
@@ -56,7 +64,11 @@ func nut_top() SDF3 {
 //-----------------------------------------------------------------------------
 
 func main() {
-	RenderSTL(bolt_container(), 200, "container.stl")
+	bc, err := bolt_container()
+	if err != nil {
+		log.Fatal(err)
+	}
+	RenderSTL(bc, 200, "container.stl")
 }
 
 //-----------------------------------------------------------------------------

--- a/examples/test/main.go
+++ b/examples/test/main.go
@@ -355,11 +355,16 @@ func test36() {
 	RenderSTL(Extrude3D(s_driven, 10), 200, "driven.stl")
 }
 
-func test37() {
+func test37() error {
 	r := 5.0
 	p := 2.0
-	s := Screw3D(ISOThread(r, p, "external"), 50, p, 1)
+	isoThread, err := ISOThread(r, p, "external")
+	if err != nil {
+		return err
+	}
+	s := Screw3D(isoThread, 50, p, 1)
 	RenderSTL(s, 400, "screw.stl")
+	return nil
 }
 
 func test39() {

--- a/sdf/screw.go
+++ b/sdf/screw.go
@@ -154,16 +154,20 @@ func ThreadLookup(name string) (*ThreadParameters, error) {
 }
 
 // HexRadius returns the hex head radius.
-func (t *ThreadParameters) HexRadius() float64 {
+func (t *ThreadParameters) HexRadius() (float64, error) {
 	if t.HexFlat2Flat < 0 {
-		panic("no hex head flat to flat distance defined for this thread")
+		return 0, fmt.Errorf("no hex head flat to flat distance defined for this thread")
 	}
-	return t.HexFlat2Flat / (2.0 * math.Cos(DtoR(30)))
+	return t.HexFlat2Flat / (2.0 * math.Cos(DtoR(30))), nil
 }
 
 // HexHeight returns the hex head height (empirical).
-func (t *ThreadParameters) HexHeight() float64 {
-	return 2.0 * t.HexRadius() * (5.0 / 12.0)
+func (t *ThreadParameters) HexHeight() (float64, error) {
+	hexRadius, err := t.HexRadius()
+	if err != nil {
+		return 0, err
+	}
+	return 2.0 * hexRadius * (5.0 / 12.0), nil
 }
 
 //-----------------------------------------------------------------------------
@@ -202,7 +206,7 @@ func ISOThread(
 	radius float64, // radius of thread
 	pitch float64, // thread to thread distance
 	mode string, // internal/external thread
-) SDF2 {
+) (SDF2, error) {
 
 	theta := DtoR(30.0)
 	h := pitch / (2.0 * math.Tan(theta))
@@ -233,10 +237,10 @@ func ISOThread(
 		iso.Add(-pitch, rMinor)
 		iso.Add(-pitch, 0)
 	} else {
-		panic("bad mode")
+		return nil, fmt.Errorf("bad mode")
 	}
 	//iso.Render("iso.dxf")
-	return Polygon2D(iso.Vertices())
+	return Polygon2D(iso.Vertices()), nil
 }
 
 // ANSIButtressThread returns the 2d profile for an ANSI 45/7 buttress thread.

--- a/sdf/shapes3.go
+++ b/sdf/shapes3.go
@@ -313,9 +313,16 @@ func Bolt(k *BoltParms) (SDF3, error) {
 	}
 
 	// head
-	hr := t.HexRadius()
-	hh := t.HexHeight()
 	var head SDF3
+
+	hr, err := t.HexRadius()
+	if err != nil {
+		return nil, err
+	}
+	hh, err := t.HexHeight()
+	if err != nil {
+		return nil, err
+	}
 	switch k.Style {
 	case "hex":
 		head = HexHead3D(hr, hh, "b")
@@ -340,7 +347,11 @@ func Bolt(k *BoltParms) (SDF3, error) {
 	if threadLength != 0 {
 		r := t.Radius - k.Tolerance
 		threadOffset := threadLength/2 + shankLength
-		thread = Screw3D(ISOThread(r, t.Pitch, "external"), threadLength, t.Pitch, 1)
+		isoThread, err := ISOThread(r, t.Pitch, "external")
+		if err != nil {
+			return nil, err
+		}
+		thread = Screw3D(isoThread, threadLength, t.Pitch, 1)
 		// chamfer the thread
 		thread = ChamferedCylinder(thread, 0, 0.5)
 		thread = Transform3D(thread, Translate3d(V3{0, 0, threadOffset}))
@@ -372,8 +383,14 @@ func Nut(k *NutParms) (SDF3, error) {
 
 	// nut body
 	var nut SDF3
-	nr := t.HexRadius()
-	nh := t.HexHeight()
+	nr, err := t.HexRadius()
+	if err != nil {
+		return nut, err
+	}
+	nh, err := t.HexHeight()
+	if err != nil {
+		return nut, err
+	}
 	switch k.Style {
 	case "hex":
 		nut = HexHead3D(nr, nh, "tb")
@@ -384,7 +401,11 @@ func Nut(k *NutParms) (SDF3, error) {
 	}
 
 	// internal thread
-	thread := Screw3D(ISOThread(t.Radius+k.Tolerance, t.Pitch, "internal"), nh, t.Pitch, 1)
+	isoThread, err := ISOThread(t.Radius+k.Tolerance, t.Pitch, "internal")
+	if err != nil {
+		return nil, err
+	}
+	thread := Screw3D(isoThread, nh, t.Pitch, 1)
 
 	return Difference3D(nut, thread), nil
 }


### PR DESCRIPTION
- partially fixes shapes3.go and examples files:
  - examples/bolt_container/main.go
  - examples/fidget/main.go
  - examples/test/main.go